### PR TITLE
Added instructions on installing the Si5351 library to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # bitx40
 BITX40 sketch for Raduino
+
+## Si5351 Library
+
+This sketch uses the Si5351 library v1.x ([https://github.com/etherkit/Si5351Arduino](https://github.com/etherkit/Si5351Arduino)). The easiest way to install this library (assuming you are using Arduino IDE 1.6.2 or greater) is to use the Arduino Library Manager.  To install it this way, simply go to the menu `Sketch > Include Library > Manage Libraries...`, and then in the search box at the upper-right, type `Etherkit Si5351`. Click on the entry in the list below, select `Version 1.1.1` from the drop down menu and then click on the "Install" button. By installing the library this way, you will always have notifications of future library updates, and can easily switch between library versions.


### PR DESCRIPTION
The sketch does not compile if you install the latest version of the Si5351 library from Etherkit.  I have added instructions to the README to describe the installation process for version 1.1.1 of the library.